### PR TITLE
Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 src
+*.log

--- a/Autopilot.py
+++ b/Autopilot.py
@@ -2,9 +2,9 @@ import math
 
 from robocluster import Device
 
-from roverutil import getnetwork
+import config
 
-Autopilot = Device('Autopilot', 'rover', network=getnetwork())
+Autopilot = Device('Autopilot', 'rover', network=config.network)
 
 LOOP_PERIOD = 0.1
 MIN_WHEEL_RPM = 1000

--- a/Autopilot.py
+++ b/Autopilot.py
@@ -10,8 +10,8 @@ Autopilot = Device('Autopilot', 'rover', network=config.network)
 LOOP_PERIOD = 0.1
 MIN_WHEEL_RPM = 1000
 MAX_SPEED = 2 # m/s
-BEARING_THRESH = 5 # degrees
-GPS_DISTANCE_THRESH = 5 # meters
+BEARING_THRESH = 10 # degrees
+GPS_DISTANCE_THRESH = 1 # meters
 
 ###### Initialization ########
 
@@ -42,15 +42,17 @@ async def drive_to_target():
             bearing = await Autopilot.request('Navigation', 'bearing', position, waypoints[0])
             bearing = bearing%360
             heading = await Autopilot.request('Navigation', 'RoverHeading')
+            distance = await Autopilot.request('Navigation', 'distance', position, waypoints[0])
             a = bearing - heading
             a = (a+180)%360 - 180 # find smallest angle difference
-            if abs(a) > BEARING_THRESH:
+            if abs(a) > BEARING_THRESH + distance/10:
                 if a >= 0: # Turn right
+                    log.info('Turn right')
                     await Autopilot.send('DriveSystem', 'RotateRight', MAX_SPEED/60)
                 else: # Turn left
+                    log.info('Turn left')
                     await Autopilot.send('DriveSystem', 'RotateLeft', MAX_SPEED/60)
                 return
-            distance = await Autopilot.request('Navigation', 'distance', position, waypoints[0])
             log.info("distance from {} to {} = {}".format(position, waypoints[0], distance))
             if distance > GPS_DISTANCE_THRESH:
                 await Autopilot.send('DriveSystem', 'DriveForward', MAX_SPEED)

--- a/DriveProcess.py
+++ b/DriveProcess.py
@@ -6,6 +6,8 @@ from robocluster import Device
 
 import config
 
+log = config.getLogger()
+
 RPM_TO_ERPM = 12*19 # 12 poles, 19:1 gearbox
 
 # Limits for Electronic RPM.
@@ -157,7 +159,7 @@ async def Rtrigger_callback(Rtrigger, trigger):
 async def setLeftWheelSpeed(rpm):
     rpm = rpm*RPM_TO_ERPM
     rpm = min(rpm, MAX_RPM)
-    print(rpm)
+    log.debug('Left RPM: {}'.format(rpm))
     await DriveDevice.publish("wheelLF", {'SetRPM':DirectionConstants['wheelLF']*rpm})
     await DriveDevice.publish("wheelLM", {'SetRPM':DirectionConstants['wheelLM']*rpm})
     await DriveDevice.publish("wheelLB", {'SetRPM':DirectionConstants['wheelLB']*rpm})
@@ -165,7 +167,8 @@ async def setLeftWheelSpeed(rpm):
 async def setRightWheelSpeed(rpm):
     rpm = rpm*RPM_TO_ERPM
     rpm = min(rpm, MAX_RPM)
-    print(rpm)
+    log.debug('Right RPM: {}'.format(rpm))
+    await DriveDevice.publish("wheelLF", {'SetRPM':DirectionConstants['wheelLF']*rpm})
     await DriveDevice.publish("wheelRF", {'SetRPM':DirectionConstants['wheelRF']*rpm})
     await DriveDevice.publish("wheelRM", {'SetRPM':DirectionConstants['wheelRM']*rpm})
     await DriveDevice.publish("wheelRB", {'SetRPM':DirectionConstants['wheelRB']*rpm})

--- a/DriveProcess.py
+++ b/DriveProcess.py
@@ -4,7 +4,7 @@ from math import expm1 # e**x - 1  for rpm/current curves
 from math import exp
 from robocluster import Device
 
-from roverutil import getnetwork
+import config
 
 RPM_TO_ERPM = 12*19 # 12 poles, 19:1 gearbox
 
@@ -77,7 +77,7 @@ def austin_current_curve(f):
         return -a*MAX_CURRENT*100
 
 
-DriveDevice = Device('DriveSystem', 'rover', network=getnetwork())
+DriveDevice = Device('DriveSystem', 'rover', network=config.network)
 
 # Initialize setup variables
 DriveDevice.storage.right_brake = False

--- a/GPSdriver.py
+++ b/GPSdriver.py
@@ -96,7 +96,7 @@ async def loop():
                     await GPSdevice.publish('singlePointGPS',
                             [mean(lats), mean(longs)])
                 else:
-                    log.warning("Failed to take GPS averege", "WARNING")
+                    log.warning("Failed to take GPS averege")
                 msg = piksi.poll(MSG_VEL_NED)
                 if msg is not None:
                     await GPSdevice.publish("GPSVelocity", [msg.n/1000, msg.e/1000])

--- a/GPSdriver.py
+++ b/GPSdriver.py
@@ -7,8 +7,7 @@ import sys
 from robocluster import Device
 
 from libraries.GPS.Piksi import Piksi
-
-from roverutil import getnetwork
+import config
 
 ## Global Variables
 LOOP_PERIOD = 0.1 # How often we pusblish positions
@@ -66,7 +65,7 @@ class GPSPosition:
         return GPSPosition(math.degrees(target_lat), math.degrees(target_lon))
 
 
-GPSdevice = Device('GPSdevice', 'rover', network=getnetwork())
+GPSdevice = Device('GPSdevice', 'rover', network=config.network)
 
 #@GPSdevice.every('1s')
 async def dummy():

--- a/GPSdriver.py
+++ b/GPSdriver.py
@@ -8,6 +8,7 @@ from robocluster import Device
 
 from libraries.GPS.Piksi import Piksi
 import config
+log = config.getLogger()
 
 ## Global Variables
 LOOP_PERIOD = 0.1 # How often we pusblish positions
@@ -78,7 +79,7 @@ async def loop():
         while True:
             connected = piksi.connected()
             if not connected:
-                print("Rover piksi is not connected properly")
+                log.error("Rover piksi is not connected properly")
             else:
                 # print("Rover piksi is connected")
                 lats = []
@@ -95,14 +96,14 @@ async def loop():
                     await GPSdevice.publish('singlePointGPS',
                             [mean(lats), mean(longs)])
                 else:
-                    print("Failed to take GPS averege", "WARNING")
+                    log.warning("Failed to take GPS averege", "WARNING")
                 msg = piksi.poll(MSG_VEL_NED)
                 if msg is not None:
                     await GPSdevice.publish("GPSVelocity", [msg.n/1000, msg.e/1000])
             await GPSdevice.sleep(LOOP_PERIOD)
 
-if len(sys.argv) == 3:
-    SERIAL = sys.argv[3]
+if len(sys.argv) == 2:
+    SERIAL = sys.argv[2]
 else:
     print('Usage: GPSdriver.py <path-to-piksi>')
     print('Using default /dev/ttyUSB0')

--- a/JoystickProcess.py
+++ b/JoystickProcess.py
@@ -1,9 +1,10 @@
 import time
 import os
-from roverutil import getnetwork
 
 import pygame
 from robocluster import Device
+
+import config
 
 LOOP_PERIOD = 0.1 # seconds
 
@@ -11,7 +12,7 @@ os.environ["SDL_VIDEODRIVER"] = "dummy"
 pygame.init()
 pygame.joystick.init()
 
-JoystickDevice = Device('JoystickDevice', 'rover', network=getnetwork())
+JoystickDevice = Device('JoystickDevice', 'rover', network=config.network)
 
 JoystickDevice.storage.joystick1 = pygame.joystick.Joystick(0)
 JoystickDevice.storage.joystick1.init()

--- a/JoystickProcess.py
+++ b/JoystickProcess.py
@@ -5,6 +5,7 @@ import pygame
 from robocluster import Device
 
 import config
+log = config.getLogger()
 
 LOOP_PERIOD = 0.1 # seconds
 

--- a/KalmanFilterProcess.py
+++ b/KalmanFilterProcess.py
@@ -5,11 +5,12 @@ from robocluster import Device
 import random as random
 import matplotlib.pyplot as plt
 import time
-from roverutil import getnetwork
 
-KalmanFilter = Device('KalmanFilter', 'rover', network=getnetwork())
+import config
 
-DummyGPS = Device('DummyGPS', 'rover', network=getnetwork())
+KalmanFilter = Device('KalmanFilter', 'rover', network=config.network)
+
+DummyGPS = Device('DummyGPS', 'rover', network=config.network)
 # @DummyGPS.every('0.1s')
 async def dummy():
     #await DummyGPS.publish('singlePointGPS', [51.00000+(random.randrange(400, 600)/1000000), 110.00000+(random.randrange(600, 800)/1000000)])

--- a/KalmanFilterProcess.py
+++ b/KalmanFilterProcess.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import time
 
 import config
+log = config.getLogger()
 
 KalmanFilter = Device('KalmanFilter', 'rover', network=config.network)
 
@@ -184,8 +185,8 @@ async def kalman_filter(event, data):
     true_gps = utm.to_latlon(x_cc[0, 0], x_cc[1, 0], zone_info[0], zone_info[1], strict=False)  # this has the value we
     cart_pos_final = [x_cc[0,0], x_cc[1,0]]
 
-    # print('raw: {}'.format(data))
-    # print("                                             filtered: {}".format(true_gps))
+    log.debug('raw: {}'.format(data))
+    log.debug("filtered: {}".format(true_gps))
 
     ''' pres = 0.00001
     dif_lat = abs(true_gps[0] - 52.132653)

--- a/NavigationProcess.py
+++ b/NavigationProcess.py
@@ -10,7 +10,7 @@ from robocluster import Device
 
 from libraries.GPS.GPSPosition import GPSPosition
 
-from roverutil import getnetwork
+import config
 
 
 class Rover:
@@ -23,7 +23,7 @@ class Rover:
         self.roll = 0
 
 
-NavDevice = Device('Navigation', 'rover', getnetwork())
+NavDevice = Device('Navigation', 'rover', network=config.network)
 
 NavDevice.storage.rover = Rover()
 # NavDevice.storage.waypoints = [(52.132866, -106.628012)]

--- a/NavigationProcess.py
+++ b/NavigationProcess.py
@@ -28,7 +28,7 @@ NavDevice = Device('Navigation', 'rover', network=config.network)
 
 NavDevice.storage.rover = Rover()
 # NavDevice.storage.waypoints = [(52.132866, -106.628012)]
-NavDevice.storage.waypoints = [(52.132774, -106.627528)]
+NavDevice.storage.waypoints = [(52.132458, -106.627159)]
 
 @NavDevice.on('*/FilteredGPS')
 @NavDevice.on('*/GPSPosition')
@@ -42,7 +42,7 @@ def update_heading(event, data):
 
 @NavDevice.on('*/CompassDataMessage')
 def compas_callback(event, data):
-    NavDevice.storage.rover.heading = data['heading']+10.26667 #magnetic declination offset 10.58333 for Hanksville
+    NavDevice.storage.rover.heading = data['heading'] #magnetic declination offset 10.58333 for Hanksville 10.26667 for SK
     NavDevice.storage.rover.pitch = data['pitch']
     NavDevice.storage.rover.roll = data['roll']
 

--- a/NavigationProcess.py
+++ b/NavigationProcess.py
@@ -11,6 +11,7 @@ from robocluster import Device
 from libraries.GPS.GPSPosition import GPSPosition
 
 import config
+log = config.getLogger()
 
 
 class Rover:

--- a/Printer.py
+++ b/Printer.py
@@ -1,12 +1,11 @@
 from robocluster import Device
-
-from roverutil import getnetwork
+import config
 
 '''
 Just prints everything it published from the robocluster network.
 '''
 
-printer = Device('printer', 'rover', network=getnetwork())
+printer = Device('printer', 'rover', network=config.network)
 
 @printer.on('*/*')
 def print_it(event, data):

--- a/Printer.py
+++ b/Printer.py
@@ -1,3 +1,4 @@
+import logging
 from robocluster import Device
 import config
 
@@ -5,11 +6,13 @@ import config
 Just prints everything it published from the robocluster network.
 '''
 
+log = config.getLogger()
+
 printer = Device('printer', 'rover', network=config.network)
 
 @printer.on('*/*')
 def print_it(event, data):
-    print(event, data)
+    log.info("{}: {}".format(event, data))
 
 
 printer.start()

--- a/Simulator.py
+++ b/Simulator.py
@@ -61,6 +61,8 @@ def simulate_bno(accel):
 
 simDevice = Device('simDevice', 'rover', network=config.network)
 
+log = config.getLogger()
+
 # Rover parameters
 simDevice.storage.rover = Rover()
 simDevice.storage.rover.wheelspeed = [0, 0]
@@ -71,10 +73,10 @@ DELTA_T = 0.1
 async def update():
     simDevice.storage.rover.update(DELTA_T)
     # simDevice.storage.rover.wheelspeed = [x+0.1 for x in simDevice.storage.rover.wheelspeed]
-    # print('position', simDevice.storage.rover.position)
-    # print('wheel speed', simDevice.storage.rover.wheelspeed)
-    # print('heading', simDevice.storage.rover.heading)
-    # print('accleration', simDevice.storage.rover.acceleration)
+    log.debug('position: {}'.format(simDevice.storage.rover.position))
+    log.debug('wheel speed: {}'.format(simDevice.storage.rover.wheelspeed))
+    log.debug('heading: {}'.format(simDevice.storage.rover.heading))
+    log.debug('accleration: {}'.format(simDevice.storage.rover.acceleration))
 
 @simDevice.every(DELTA_T)
 async def publish_state():

--- a/Simulator.py
+++ b/Simulator.py
@@ -6,7 +6,7 @@ from robocluster import Device
 from libraries.GPS.GPSPosition import GPSPosition
 from libraries.differential_drive import diff_drive_fk
 
-from roverutil import getnetwork
+import config
 
 class Rover:
 
@@ -59,7 +59,7 @@ def simulate_bno(accel):
     return [random.gauss(accel[0], stddev_x),
             random.gauss(accel[1], stddev_y)]
 
-simDevice = Device('simDevice', 'rover', network=getnetwork())
+simDevice = Device('simDevice', 'rover', network=config.network)
 
 # Rover parameters
 simDevice.storage.rover = Rover()

--- a/USBmanager.py
+++ b/USBmanager.py
@@ -10,12 +10,12 @@ import serial
 
 from VESCdriver import VESCDriver
 from JSONdriver import JSONDriver
-from roverutil import getnetwork
+import config
 
 IGNORE_LIST = ['/dev/ttyS0', '/dev/ttyAMA0', '/dev/ttyUSB0']
 
 
-manager = Device('USBManager', 'rover', network=getnetwork())
+manager = Device('USBManager', 'rover', network=config.network)
 manager.storage.drivers = {}
 manager.storage.sub_map = {}
 

--- a/config.py
+++ b/config.py
@@ -1,28 +1,51 @@
 # Put constants/variables all processes need to share in here
 import logging
+import inspect
 
 network = '0.0.0.0/0'
 
-loglevel = logging.DEBUG
+default_level = logging.DEBUG
+level_map = {
+    'Printer': default_level,
+    'Autopilot': default_level,
+    'USBmanager': default_level,
+    'JoystickProcess': default_level,
+    'NavigationProcess': default_level,
+    'DriveProcess': default_level,
+    'KalmanFilterProcess': default_level,
+    'GPSDriver': default_level,
+}
+
+log_filter_string = ''
 
 logfile_path = 'log.log'
 
 def getLogger():
-    logger = logging.getLogger()
-    formatter = logging.Formatter('%(asctime)s | %(module)-10s| %(levelname)-8s| %(message)s')
+    frame = inspect.stack()[1]
+    name = frame.filename[:-3] # strip off .py extension
+    logger = logging.getLogger(name)
+    formatter = logging.Formatter('%(asctime)s | %(name)-10s| %(levelname)-8s| %(message)s')
+    log_filter = logging.Filter(log_filter_string)
 
     # Console logging
     console_log = logging.StreamHandler()
     console_log.setFormatter(formatter)
     console_log.setLevel(logging.INFO)
+    console_log.addFilter(log_filter)
 
     # File logging
     file_log = logging.FileHandler(logfile_path)
     file_log.setFormatter(formatter)
     file_log.setLevel(logging.DEBUG)
+    # file_log.addFilter(log_filter)
 
     logger.addHandler(console_log)
     logger.addHandler(file_log)
-    logger.setLevel(loglevel)
+
+    if name in level_map: # should this maybe be just for console log?
+        level = level_map[name]
+    else:
+        level = default_level
+    logger.setLevel(level)
 
     return logger

--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ def getLogger():
     logger = logging.getLogger()
     formatter = logging.Formatter('%(asctime)s | %(module)-10s| %(levelname)-8s| %(message)s')
 
+    # Console logging
     console_log = logging.StreamHandler()
     console_log.setFormatter(formatter)
     console_log.setLevel(logging.INFO)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,3 @@
+# Put constants/variables all processes need to share in here
+
+network = '0.0.0.0/0'

--- a/config.py
+++ b/config.py
@@ -1,3 +1,27 @@
 # Put constants/variables all processes need to share in here
+import logging
 
 network = '0.0.0.0/0'
+
+loglevel = logging.DEBUG
+
+logfile_path = 'log.log'
+
+def getLogger():
+    logger = logging.getLogger()
+    formatter = logging.Formatter('%(asctime)s | %(module)-10s| %(levelname)-8s| %(message)s')
+
+    console_log = logging.StreamHandler()
+    console_log.setFormatter(formatter)
+    console_log.setLevel(logging.INFO)
+
+    # File logging
+    file_log = logging.FileHandler(logfile_path)
+    file_log.setFormatter(formatter)
+    file_log.setLevel(logging.DEBUG)
+
+    logger.addHandler(console_log)
+    logger.addHandler(file_log)
+    logger.setLevel(loglevel)
+
+    return logger

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ network=config.network
 process_list = [
     RunOnce('USBManager', 'python3 USBmanager.py'),
     # RunOnce('Printer', 'python3 Printer.py'),
-    RunOnce('GPSDriver', 'python3 GPSdriver.py'),
+    # RunOnce('GPSDriver', 'python3 GPSdriver.py'),
     RunOnce('DriveControl', 'python3 DriveProcess.py'),
     # RunOnce('Joystick', 'python3 JoystickProcess.py'),
     RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),

--- a/main.py
+++ b/main.py
@@ -1,19 +1,20 @@
 from robocluster.manager import ProcessManager, RunOnce
 import time
+import config
 
-network='0.0.0.0/0'
+network=config.network
 
 process_list = [
-    # RunOnce('USBManager', 'python3 USBmanager.py {}'.format(network)),
-    # RunOnce('Printer', 'python3 Printer.py {}'.format(network)),
-    # RunOnce('GPSDriver', 'python3 GPSdriver.py {}'.format(network)),
-    RunOnce('DriveControl', 'python3 DriveProcess.py {}'.format(network)),
-    # RunOnce('Joystick', 'python3 JoystickProcess.py {}'.format(network)),
-    # RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py {}'.format(network)),
-    RunOnce('Autopilot', 'python3 Autopilot.py {}'.format(network)),
-    RunOnce('WebUI', 'python3 server.py {}'.format(network), cwd='rover-webui'),
-    RunOnce('Navigation', 'python3 NavigationProcess.py {}'.format(network)),
-    RunOnce('Simulator', 'python3 Simulator.py {}'.format(network)),
+    RunOnce('USBManager', 'python3 USBmanager.py'),
+    RunOnce('Printer', 'python3 Printer.py'),
+    # RunOnce('GPSDriver', 'python3 GPSdriver.py'),
+    RunOnce('DriveControl', 'python3 DriveProcess.py'),
+    RunOnce('Joystick', 'python3 JoystickProcess.py'),
+    RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
+    RunOnce('Autopilot', 'python3 Autopilot.py'),
+    RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),
+    RunOnce('Navigation', 'python3 NavigationProcess.py'),
+    RunOnce('Simulator', 'python3 Simulator.py'),
 ]
 
 

--- a/main.py
+++ b/main.py
@@ -7,14 +7,14 @@ network=config.network
 process_list = [
     RunOnce('USBManager', 'python3 USBmanager.py'),
     # RunOnce('Printer', 'python3 Printer.py'),
-    # RunOnce('GPSDriver', 'python3 GPSdriver.py'),
+    RunOnce('GPSDriver', 'python3 GPSdriver.py'),
     RunOnce('DriveControl', 'python3 DriveProcess.py'),
-    RunOnce('Joystick', 'python3 JoystickProcess.py'),
+    # RunOnce('Joystick', 'python3 JoystickProcess.py'),
     RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
     RunOnce('Autopilot', 'python3 Autopilot.py'),
     RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),
     RunOnce('Navigation', 'python3 NavigationProcess.py'),
-    RunOnce('Simulator', 'python3 Simulator.py'),
+    # RunOnce('Simulator', 'python3 Simulator.py'),
 ]
 
 

--- a/main.py
+++ b/main.py
@@ -5,15 +5,15 @@ import config
 network=config.network
 
 process_list = [
-    RunOnce('USBManager', 'python3 USBmanager.py'),
+    # RunOnce('USBManager', 'python3 USBmanager.py'),
     RunOnce('Printer', 'python3 Printer.py'),
     # RunOnce('GPSDriver', 'python3 GPSdriver.py'),
-    RunOnce('DriveControl', 'python3 DriveProcess.py'),
-    RunOnce('Joystick', 'python3 JoystickProcess.py'),
-    RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
-    RunOnce('Autopilot', 'python3 Autopilot.py'),
-    RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),
-    RunOnce('Navigation', 'python3 NavigationProcess.py'),
+    # RunOnce('DriveControl', 'python3 DriveProcess.py'),
+    # RunOnce('Joystick', 'python3 JoystickProcess.py'),
+    # RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
+    # RunOnce('Autopilot', 'python3 Autopilot.py'),
+    # RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),
+    # RunOnce('Navigation', 'python3 NavigationProcess.py'),
     RunOnce('Simulator', 'python3 Simulator.py'),
 ]
 

--- a/main.py
+++ b/main.py
@@ -5,15 +5,15 @@ import config
 network=config.network
 
 process_list = [
-    # RunOnce('USBManager', 'python3 USBmanager.py'),
-    RunOnce('Printer', 'python3 Printer.py'),
+    RunOnce('USBManager', 'python3 USBmanager.py'),
+    # RunOnce('Printer', 'python3 Printer.py'),
     # RunOnce('GPSDriver', 'python3 GPSdriver.py'),
-    # RunOnce('DriveControl', 'python3 DriveProcess.py'),
-    # RunOnce('Joystick', 'python3 JoystickProcess.py'),
-    # RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
-    # RunOnce('Autopilot', 'python3 Autopilot.py'),
-    # RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),
-    # RunOnce('Navigation', 'python3 NavigationProcess.py'),
+    RunOnce('DriveControl', 'python3 DriveProcess.py'),
+    RunOnce('Joystick', 'python3 JoystickProcess.py'),
+    RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
+    RunOnce('Autopilot', 'python3 Autopilot.py'),
+    RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),
+    RunOnce('Navigation', 'python3 NavigationProcess.py'),
     RunOnce('Simulator', 'python3 Simulator.py'),
 ]
 


### PR DESCRIPTION
This adds a long overdue setup for logging messages instead of using print statements. Any information that you want to be seen should be done via logging instead of print statements from now on.

All proceses have `log = config.getLogger()` right after importing `config`, and in your code just use `log.info('<message>'`, `log.debug('msg')`, log.warning('msg')`, etc.

I was going to merge the `config` branch as a separate PR, but I'll just be lazy and use this to include those changes. There is now a config.py where all configuration such as network address should go.