### PR TITLE
Catch JSON decode error on driver.read

### DIFF
--- a/JSONdriver.py
+++ b/JSONdriver.py
@@ -44,10 +44,13 @@ class JSONDriver:
     def read(self):
         '''Read a json message from the device'''
         # from Roveberrypy
-        size = self.ser.read(1) # this is assuming a message is less than 256 bytes
-        length = int.from_bytes(size, byteorder='big')
-        packet = self.ser.read(length)
-        return json.loads(packet.decode('utf8'))
+        try:
+            size = self.ser.read(1) # this is assuming a message is less than 256 bytes
+            length = int.from_bytes(size, byteorder='big')
+            packet = self.ser.read(length)
+            return json.loads(packet.decode('utf8'))
+        except json.decoder.JSONDecodeError:
+            return None
 
     def start_reader(self, callback):
         ''' Starts a background reader thread.

--- a/main.py
+++ b/main.py
@@ -5,11 +5,11 @@ import config
 network=config.network
 
 process_list = [
-    # RunOnce('USBManager', 'python3 USBmanager.py'),
-    # RunOnce('Printer', 'python3 Printer.py'),
+    RunOnce('USBManager', 'python3 USBmanager.py'),
+    RunOnce('Printer', 'python3 Printer.py'),
     # RunOnce('GPSDriver', 'python3 GPSdriver.py'),
     # RunOnce('DriveControl', 'python3 DriveProcess.py'),
-    RunOnce('Joystick', 'python3 JoystickProcess.py'),
+    # RunOnce('Joystick', 'python3 JoystickProcess.py'),
     # RunOnce('KalmanFilter', 'python3 KalmanFilterProcess.py'),
     # RunOnce('Autopilot', 'python3 Autopilot.py'),
     # RunOnce('WebUI', 'python3 server.py', cwd='rover-webui'),


### PR DESCRIPTION
My last PR caught json decode errors durring initialization, but this adds robustness after that.