### PR TITLE
Logfiles named by datetime

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,8 @@
 # Put constants/variables all processes need to share in here
 import logging
 import inspect
+import time
+import os
 
 network = '0.0.0.0/0'
 
@@ -18,7 +20,11 @@ level_map = {
 
 log_filter_string = ''
 
-logfile_path = 'log.log'
+if not os.path.isdir('./logs'):
+    os.makedirs('logs')
+# Day-Month(abbrviation)-Year:24Hour:Minute
+time_string = time.strftime('%d-%b-%Y:%H:%M')
+logfile_path = './logs/{}.log'.format(time_string)
 
 def getLogger():
     frame = inspect.stack()[1]


### PR DESCRIPTION
Multiple logfiles are created when you run the rover software, and saved with the date and time (minute resolution) as the filename.